### PR TITLE
fix port issue in docker compose environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,11 +12,11 @@ services:
       - "./.steedos:/app/.steedos"
     environment:
       - ROOT_URL=http://localhost:5000
-      - MONGO_URL=mongodb://mongo:27018/steedos
+      - MONGO_URL=mongodb://mongo:27017/steedos
       - STEEDOS_CFS_STORE=local
       - STEEDOS_STORAGE_DIR=/app/storage
-      - TRANSPORTER=redis://redis:6389
-      - CACHER=redis://redis:6389/2
+      - TRANSPORTER=redis://redis:6379
+      - CACHER=redis://redis:6379/2
     depends_on:
       - redis
       - mongo


### PR DESCRIPTION

Errors:
```
foa-steedos-1             | [2022-03-27T01:05:34.720Z] ERROR a2066dc35d60-54/TRANSPORTER: Redis-sub error connect ECONNREFUSED 172.18.0.3:6389
foa-steedos-1             | [2022-03-27T01:05:34.720Z] WARN  a2066dc35d60-54/TRANSPORTER: Redis-sub client is disconnected.
foa-steedos-1             | [2022-03-27T01:05:35.574Z] ERROR a2066dc35d60-54/TRANSPORTER: Redis-sub error connect ECONNREFUSED 172.18.0.3:6389
foa-steedos-1             | [2022-03-27T01:05:35.574Z] WARN  a2066dc35d60-54/TRANSPORTER: Redis-sub client is disconnected.
foa-steedos-1             | [2022-03-27T01:05:35.574Z] ERROR a2066dc35d60-54/CACHER: Error: connect ECONNREFUSED 172.18.0.3:6389
foa-steedos-1             |     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1144:16) {
foa-steedos-1             |   errno: 'ECONNREFUSED',
foa-steedos-1             |   code: 'ECONNREFUSED',
foa-steedos-1             |   syscall: 'connect',
foa-steedos-1             |   address: '172.18.0.3',
foa-steedos-1             |   port: 6389
foa-steedos-1             | }
```

```
foa-steedos-1             | [2022-03-27T01:16:20.255Z] ERROR f5b442ec6784-52/BROKER: Unable to start all services. MongoServerSelectionError: connect ECONNREFUSED 172.18.0.2:27018
foa-steedos-1             |     at Timeout._onTimeout (/app/node_modules/mongodb/lib/core/sdam/topology.js:438:30)
foa-steedos-1             |     at listOnTimeout (internal/timers.js:554:17)
foa-steedos-1             |     at processTimers (internal/timers.js:497:7) {
foa-steedos-1             |   reason: TopologyDescription { type: 'Single', setName: null, maxSetVersion: null, maxElectionId: null, servers: Map { 'mongo:27018' => [ServerDescription] }, stale: false, compatible: true, compatibilityError: null, logicalSessionTimeoutMinutes: null, heartbeatFrequencyMS: 10000, localThresholdMS: 15, commonWireVersion: null }
foa-steedos-1             | }
foa-steedos-1             | [Runner] connect ECONNREFUSED 172.18.0.2:27018 MongoServerSelectionError: connect ECONNREFUSED 172.18.0.2:27018
foa-steedos-1             |     at Timeout._onTimeout (/app/node_modules/mongodb/lib/core/sdam/topology.js:438:30)
foa-steedos-1             |     at listOnTimeout (internal/timers.js:554:17)
foa-steedos-1             |     at processTimers (internal/timers.js:497:7) {
foa-steedos-1             |   reason: TopologyDescription {
foa-steedos-1             |     type: 'Single',
foa-steedos-1             |     setName: null,
foa-steedos-1             |     maxSetVersion: null,
foa-steedos-1             |     maxElectionId: null,
foa-steedos-1             |     servers: Map { 'mongo:27018' => [ServerDescription] },
foa-steedos-1             |     stale: false,
foa-steedos-1             |     compatible: true,
foa-steedos-1             |     compatibilityError: null,
foa-steedos-1             |     logicalSessionTimeoutMinutes: null,
foa-steedos-1             |     heartbeatFrequencyMS: 10000,
foa-steedos-1             |     localThresholdMS: 15,
foa-steedos-1             |     commonWireVersion: null
foa-steedos-1             |   }
foa-steedos-1             | }
foa-steedos-1             | error Command failed with exit code 1.
foa-steedos-1             | info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
foa-steedos-1 exited with code 1
```
